### PR TITLE
fix: storybook deploy

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -32,5 +32,6 @@ jobs:
       - id: build-publish
         uses: bitovi/github-actions-storybook-to-github-pages@b75ece8f984a32b2adb322065d7a8a2cc8db2d52 # v1.0.3
         with:
+          install_command: npm ci --ignore-scripts
           path: ./storybook-static
           build_command: npm run storybook:build


### PR DESCRIPTION
## Description

I modify workflow to disallow `postinstall` that not super secure but it's stop breaking our ci.

## Related Issues

No related issues

### Check List

<!--
ATTENTION
Please follow this check list to ensure that you've followed all items before opening this PR
You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [X] I have formatted using `npx turbo format`
- [X] I have checked the types using `npx turbo type-check`
- [X] I have tested the build using `npx turbo build`
- [X] I have covered the code with tests if necessary
